### PR TITLE
Updated README.md to include a rust update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ following concepts:
 For building:
 
 ```
+rustup update
 rustup target add thumbv7em-none-eabihf
 ```
 


### PR DESCRIPTION
My (not so) old version of rust has one of the string manipulation functions used marked as experimental. Updating rust resolved this issue.